### PR TITLE
[wip] Optionally parse sync (address) byte

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/tact1m4n3/crsf-rs"
 documentation = "https://docs.rs/crsf"
 
 [dependencies]
+bitflags = "2.5.0"
 crc = "3.2"
 defmt = { version = "0.3.6", optional = true }
 num_enum = { version = "0.7.2", default-features = false }

--- a/examples/local_serial.rs
+++ b/examples/local_serial.rs
@@ -1,6 +1,6 @@
 use std::{env, io, time::Duration};
 
-use crsf::{Packet, PacketReader};
+use crsf::{Packet, PacketPayload, PacketReader};
 
 fn main() {
     let path = env::args().nth(1).expect("no serial port supplied");
@@ -10,7 +10,7 @@ fn main() {
         .expect("failed to open serial port");
 
     let mut buf = [0; 1024];
-    let mut reader = PacketReader::new();
+    let mut reader = PacketReader::default();
     loop {
         match port.read(buf.as_mut_slice()) {
             Ok(n) => {
@@ -18,11 +18,11 @@ fn main() {
                     let mut remaining = &buf[..n];
                     while let (Some(raw_packet), consumed) = reader.push_bytes(remaining) {
                         match Packet::parse(raw_packet) {
-                            Ok(packet) => match packet {
-                                Packet::LinkStatistics(link_statistics) => {
+                            Ok(packet) => match packet.payload {
+                                PacketPayload::LinkStatistics(link_statistics) => {
                                     println!("{:?}", link_statistics);
                                 }
-                                Packet::RcChannels(channels) => {
+                                PacketPayload::RcChannels(channels) => {
                                     println!("{:?}", channels);
                                 }
                                 _ => {}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,40 @@
+pub(crate) struct Buf<const C: usize> {
+    buf: [u8; C],
+    len: usize,
+}
+
+impl<const C: usize> Buf<C> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            buf: [0; C],
+            len: 0,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn push(&mut self, c: u8) -> bool {
+        if let Some(v) = self.buf.get_mut(self.len) {
+            *v = c;
+            self.len += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn push_bytes(&mut self, data: &[u8]) {
+        self.buf[self.len..self.len + data.len()].copy_from_slice(data);
+        self.len += data.len();
+    }
+
+    pub(crate) fn data(&self) -> &[u8; C] {
+        &self.buf
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.len = 0;
+    }
+}

--- a/src/packets/link_statistics.rs
+++ b/src/packets/link_statistics.rs
@@ -55,7 +55,7 @@ impl Payload for LinkStatistics {
 
 #[cfg(test)]
 mod tests {
-    use crate::{LinkStatistics, Packet};
+    use crate::{LinkStatistics, PACKET_MAX_LENGTH};
     use crate::packets::Payload;
 
     #[test]
@@ -73,7 +73,7 @@ mod tests {
             downlink_snr: -68,
         };
 
-        let mut data = [0u8; Packet::MAX_LENGTH];
+        let mut data = [0u8; PACKET_MAX_LENGTH];
         original.dump(&mut data);
 
         assert_eq!(data[0], 100_u8.to_le());

--- a/src/packets/rc_channels.rs
+++ b/src/packets/rc_channels.rs
@@ -121,7 +121,7 @@ impl core::ops::DerefMut for RcChannels {
 #[cfg(test)]
 mod tests {
     use crate::packets::Payload;
-    use crate::{Packet, RcChannels};
+    use crate::{RcChannels, PACKET_MAX_LENGTH};
 
     #[test]
     fn test_rc_channels_write_and_parse() {
@@ -130,7 +130,7 @@ mod tests {
             original[i] = i as u16 * 10;
         }
 
-        let mut data = [0u8; Packet::MAX_LENGTH];
+        let mut data = [0u8; PACKET_MAX_LENGTH];
         original.dump(&mut data);
 
         let parsed = RcChannels::parse(&data);


### PR DESCRIPTION
To be honest I'm not sure it is good solution for now.

It provides several constructors to get `PacketReader` that produces different `RawPacket` types.

Another option is to put `address: Option<PacketAddress>` field into `RawPacket` and `Packet` structs but the drawback is that we will have to check it before access (or unwrap).