### PR TITLE
Add RC-specific 0xEE sync byte

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use parser::*;
 mod util;
 
 pub const SYNC_BYTE: u8 = 0xC8;
+pub const SYNC_RC_BYTE: u8 = 0xEE;
 pub const MAX_PACKET_LEN: usize = 64;
 
 pub(crate) const CRC8: crc::Crc<u8> = crc::Crc::<u8>::new(&crc::CRC_8_DVB_S2);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ pub struct ParserConfig {
 
 impl ParserConfig {
     pub const fn default() -> Self {
-        Self { sync: &[SYNC_BYTE, SYNC_RC_BYTE] }
+        Self { sync: &[SYNC_RC_BYTE, SYNC_BYTE] }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{util::BytesReader, Packet, PacketType, RawPacket, CRC8, MAX_PACKET_LEN, SYNC_BYTE};
+use crate::{util::BytesReader, Packet, PacketType, RawPacket, CRC8, MAX_PACKET_LEN, SYNC_BYTE, SYNC_RC_BYTE};
 use snafu::Snafu;
 
 /// Struct for configuring a `Parser`.
@@ -10,7 +10,7 @@ pub struct ParserConfig {
 
 impl ParserConfig {
     pub const fn default() -> Self {
-        Self { sync: &[SYNC_BYTE] }
+        Self { sync: &[SYNC_BYTE, SYNC_RC_BYTE] }
     }
 }
 


### PR DESCRIPTION
Radiomaster controllers (TX12, TX16 models at least with EdgeTX v2.8.0-2.9.1) use 0xEE as `RcChannelsPacked` sync byte, but 0xCE for other types of messages, this makes parser to search for either of these two bytes to successfully parse all the messages.