### PR TITLE
Remove RawPacket and use slice instead

### DIFF
--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -14,16 +14,6 @@ use crate::{ParseError, CRC8, SYNC_BYTE};
 use num_enum::TryFromPrimitive;
 use snafu::Snafu;
 
-/// Wrapper struct for the raw data of a packet with valid length and checksum.
-pub struct RawPacket<'a>(pub(crate) &'a [u8]);
-
-impl RawPacket<'_> {
-    /// Returns the inner data
-    pub fn data(&self) -> &[u8] {
-        self.0
-    }
-}
-
 /// Enum of implemented packets.
 #[non_exhaustive]
 #[derive(Debug, PartialEq)]
@@ -47,10 +37,8 @@ pub enum ExtendedPacket {
 }
 
 impl Packet {
-    /// Parses a `RawPacket`
-    pub fn parse(raw_packet: RawPacket<'_>) -> Result<Self, ParseError> {
-        let data = raw_packet.data();
-
+    /// Parses raw packet data with valid length and checksum
+    pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
         let typ = if let Ok(typ) = PacketType::try_from_primitive(data[2]) {
             typ
         } else {
@@ -240,7 +228,7 @@ pub struct DumpError {
 mod tests {
     use crate::{
         DevicePing, ExtendedPacket, ExtendedPayloadDump, LinkStatistics, Packet, PacketAddress,
-        PayloadDump, RawPacket, RcChannelsPacked, MAX_PACKET_LEN, SYNC_BYTE,
+        PayloadDump, RcChannelsPacked, MAX_PACKET_LEN, SYNC_BYTE,
     };
 
     #[test]
@@ -257,7 +245,7 @@ mod tests {
 
         assert_eq!(&buf[..len], expected_data.as_slice());
 
-        let result = Packet::parse(RawPacket(&buf[..len]));
+        let result = Packet::parse(&buf[..len]);
         assert_eq!(result, Ok(Packet::RcChannelsPacked(orig)));
     }
 
@@ -285,7 +273,7 @@ mod tests {
 
         assert_eq!(&buf[..len], expected_data.as_slice());
 
-        let result = Packet::parse(RawPacket(&buf[..len]));
+        let result = Packet::parse(&buf[..len]);
         assert_eq!(result, Ok(Packet::LinkStatistics(orig)));
     }
 
@@ -308,7 +296,7 @@ mod tests {
 
         assert_eq!(&buf[..len], expected_data.as_slice());
 
-        let result = Packet::parse(RawPacket(&buf[..len]));
+        let result = Packet::parse(&buf[..len]);
         assert_eq!(
             result,
             Ok(Packet::Extended {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,7 +60,7 @@ impl Parser {
     /// Consumes a byte and returns a parsed packet if one is available.
     pub fn push_byte(&mut self, byte: u8) -> Option<Result<Packet, ParseError>> {
         self.push_byte_raw(byte)
-            .map(|res| res.and_then(|raw_packet| Packet::parse(raw_packet)))
+            .map(|res| res.and_then(Packet::parse))
     }
 
     /// Consumes a byte and returns a raw (not parsed) packet if one is available.
@@ -122,7 +122,7 @@ impl Parser {
     ) -> Option<(Result<Packet, ParseError>, &'b [u8])> {
         self.push_bytes_raw(data).map(|(res, remaining)| {
             (
-                res.and_then(|raw_packet| Packet::parse(raw_packet)),
+                res.and_then(Packet::parse),
                 remaining,
             )
         })


### PR DESCRIPTION
Here's my issue with `RawPacket` in the following example:

```rust
if let Some((Ok(raw_packet), _)) = parser.push_bytes_raw(out_buffer) {
    if let Ok(Packet::RcChannelsPacked(rc)) = Packet::parse(raw_packet) { // RawPacket gets moved here
        // we got specifically RC packet, do stuff
    }
    
    // forward RawPacket to flight controller anyway, whatever it happens to be
    // but we can not because it has been moved
    fc_port.write(raw_packet)
}
```

So, why don't we just drop it altogether and work with slices everywhere? In that case the code above just works without any changes. We will only lose a bit of semantic meaning, but arguably not much.